### PR TITLE
skip parsing and immediately re-serializing the session. 

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -50,10 +50,10 @@ app.get("/sso/metabase", async (req, res) => {
 
   try {
     const response = await fetch(ssoUrl, { method: 'GET' })
-    const token = await response.json()
+    const session = await response.text()
 
-    console.log("Received token", token)
-    return res.status(200).json(token)
+    console.log("Received session", session)
+    return res.status(200).set("Content-Type", "application/json").end(session)
   } catch (error) {
     if (error instanceof Error) {
       res.status(401).json({


### PR DESCRIPTION
This is helpful to forward possible errors that didn't come as json, part of https://github.com/metabase/metabase/issues/49762
More context on [the product doc](https://www.notion.so/metabase/Make-troubleshooting-SDK-auth-easier-11f69354c90180319a05e4b652adc249#11f69354c90180859197e284a0213f0f)

Similar to https://github.com/metabase/metabase/pull/49792 done on the docs