### PR TITLE
Convert `jwtProviderUri` to `authProviderUri`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # FRONTEND
 PORT=3100
 VITE_METABASE_INSTANCE_URL="http://localhost:3000"
-VITE_JWT_PROVIDER_URI="http://localhost:9090/sso/metabase"
+VITE_AUTH_PROVIDER_URI="http://localhost:9090/sso/metabase"
 
 # BACKEND
 BACKEND_PORT=9090

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,7 +8,7 @@ import {
 // Configuration
 const config = defineEmbeddingSdkConfig({
   metabaseInstanceUrl: import.meta.env.VITE_METABASE_INSTANCE_URL,
-  jwtProviderUri: import.meta.env.VITE_JWT_PROVIDER_URI,
+  authProviderUri: import.meta.env.VITE_AUTH_PROVIDER_URI,
 });
 
 const questionId = 14;


### PR DESCRIPTION
To match the changes from [fix(sdk): Convert jwtProviderUri to authProviderUri](https://github.com/metabase/metabase/pull/49843)