### PR TITLE
Update embedding sdk to 0.52.6 with breaking changes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Metabase embedding SDK for React sample application
 
-You'll need a Pro or Enterprise version of Metabase 50 up and running. If you're not sure where to start, sign up for [Pro Cloud](https://www.metabase.com/pricing).
+You'll need a Pro or Enterprise version of Metabase 52 up and running. If you're not sure where to start, sign up for [Pro Cloud](https://www.metabase.com/pricing).
 
 > [!IMPORTANT]
 > The SDK is currently only compatible with Metabase v1.50 or higher
@@ -28,7 +28,7 @@ On the card that says **JWT**, click the **Setup** button.
 
 ### JWT identity provider URI
 
-In the **JWT IDENTITY PROVIDER URI** field, paste  `localhost:9090/sso/metabase` (or substitute your Cloud URL for localhost).
+In the **JWT IDENTITY PROVIDER URI** field, paste `localhost:9090/sso/metabase` (or substitute your Cloud URL for localhost).
 
 In your `.env` this address is set as:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 You'll need a Pro or Enterprise version of Metabase 52 up and running. If you're not sure where to start, sign up for [Pro Cloud](https://www.metabase.com/pricing).
 
 > [!IMPORTANT]
-> The SDK is currently only compatible with Metabase v1.50 or higher
+> The SDK is compatible with Metabase v1.51 or higher
 
 ## Create `.env` file
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
-        "@metabase/embedding-sdk-react": "^1.51.4",
+        "@metabase/embedding-sdk-react": "^0.52.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1274,9 +1274,10 @@
       }
     },
     "node_modules/@metabase/embedding-sdk-react": {
-      "version": "1.51.4",
-      "resolved": "https://registry.npmjs.org/@metabase/embedding-sdk-react/-/embedding-sdk-react-1.51.4.tgz",
-      "integrity": "sha512-xksRA5EXjKrd4HmQ1Q60CauCWA8TA6+rJV19pNd2P9NHzeXhaZjg00CwEB1d29qns1OTVNPFme8fEG1o65/r0g==",
+      "version": "0.52.6",
+      "resolved": "https://registry.npmjs.org/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.52.6.tgz",
+      "integrity": "sha512-wRtfaB4tDqP55WDz6seH7PCeC1vOxZw7q6elerYKphSv9VRlZlB1f3ae/IHqfvT8XOuFGf9GOUoD7z/85grsiA==",
+      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",
@@ -1290,7 +1291,7 @@
         "@mantine/dates": "^6.0.13",
         "@mantine/hooks": "^6.0.13",
         "@react-oauth/google": "^0.11.1",
-        "@reduxjs/toolkit": "^2.2.5",
+        "@reduxjs/toolkit": "^2.3.0",
         "@snowplow/browser-tracker": "^3.1.6",
         "@tanstack/react-virtual": "^3.1.2",
         "@tippyjs/react": "^4.2.6",
@@ -1304,6 +1305,7 @@
         "@visx/shape": "^3.5.0",
         "@visx/text": "^3.3.0",
         "ace-builds": "^1.4.14",
+        "bowser": "^2.11.0",
         "buffer": "^6.0.3",
         "classnames": "^2.1.3",
         "clipboardy": "^4.0.0",
@@ -2808,6 +2810,12 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@metabase/embedding-sdk-react": "^1.51.4",
+    "@metabase/embedding-sdk-react": "^0.52.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,19 +1,21 @@
+/// <reference types="vite/client" />
+
 import {
   MetabaseProvider,
   InteractiveQuestion,
-  defineEmbeddingSdkTheme,
-  defineEmbeddingSdkConfig,
+  defineMetabaseAuthConfig,
+  defineMetabaseTheme,
 } from "@metabase/embedding-sdk-react";
 
 // Configuration
-const config = defineEmbeddingSdkConfig({
+const config = defineMetabaseAuthConfig({
   metabaseInstanceUrl: import.meta.env.VITE_METABASE_INSTANCE_URL,
   authProviderUri: import.meta.env.VITE_AUTH_PROVIDER_URI,
 });
 
 const questionId = 14;
 
-const theme = defineEmbeddingSdkTheme({
+const theme = defineMetabaseTheme({
   // Specify a font to use from the set of fonts supported by Metabase.
   // You can set the font to "Custom" to use the custom font
   // configured in your Metabase instance.
@@ -44,7 +46,6 @@ const theme = defineEmbeddingSdkTheme({
   components: {
     question: {
       backgroundColor: "#FFFFFF",
-      textColor: "#4C5773",
     },
 
     table: {
@@ -63,8 +64,8 @@ const theme = defineEmbeddingSdkTheme({
 
 function App() {
   return (
-    <div className="App" width="1200px" height="800px">
-      <MetabaseProvider config={config} theme={theme}>
+    <div className="App" style={{ width: "1200px", height: "800px" }}>
+      <MetabaseProvider authConfig={config} theme={theme}>
         <InteractiveQuestion questionId={questionId} />
       </MetabaseProvider>
     </div>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51790

Updates the sample's sdk version to latest (0.52.6) with API breaking changes applied.