### PR TITLE
Fix embedding-sdk-version in package-lock

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
-        "@metabase/embedding-sdk-react": "^0.52.12",
+        "@metabase/embedding-sdk-react": "^0.52.15",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1274,9 +1274,9 @@
       }
     },
     "node_modules/@metabase/embedding-sdk-react": {
-      "version": "0.52.12",
-      "resolved": "https://registry.npmjs.org/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.52.12.tgz",
-      "integrity": "sha512-Xt1vEiJypmPXlGLB1yy9kmNjv42NwwJ3icCrGFr8+N3asZGakQ9W712c00SI2vixQVgHGBV2bJ1xqlAH4yX5Zg==",
+      "version": "0.52.15",
+      "resolved": "https://registry.npmjs.org/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.52.15.tgz",
+      "integrity": "sha512-xAN5Uhsdto69pIANW9dnGmOmYenVewsoh+Gn1a4fPn5WEPPwPjsjMCWZirEiVl9o7HX0bjd7IZ4M76azy4FNxg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@dnd-kit/core": "^6.0.8",


### PR DESCRIPTION
Fix embedding-sdk-version in package-lock